### PR TITLE
Enable IAM based auth to ES for AWS clients (#465)

### DIFF
--- a/plugin/storage/es/options.go
+++ b/plugin/storage/es/options.go
@@ -25,18 +25,21 @@ import (
 )
 
 const (
-	suffixUsername          = ".username"
-	suffixPassword          = ".password"
-	suffixSniffer           = ".sniffer"
-	suffixServerURLs        = ".server-urls"
-	suffixMaxSpanAge        = ".max-span-age"
-	suffixNumShards         = ".num-shards"
-	suffixNumReplicas       = ".num-replicas"
-	suffixBulkSize          = ".bulk.size"
-	suffixBulkWorkers       = ".bulk.workers"
-	suffixBulkActions       = ".bulk.actions"
-	suffixBulkFlushInterval = ".bulk.flush-interval"
-	suffixIndexPrefix       = ".index-prefix"
+	suffixUsername              = ".username"
+	suffixPassword              = ".password"
+	suffixSniffer               = ".sniffer"
+	suffixServerURLs            = ".server-urls"
+	suffixMaxSpanAge            = ".max-span-age"
+	suffixNumShards             = ".num-shards"
+	suffixNumReplicas           = ".num-replicas"
+	suffixBulkSize              = ".bulk.size"
+	suffixBulkWorkers           = ".bulk.workers"
+	suffixBulkActions           = ".bulk.actions"
+	suffixBulkFlushInterval     = ".bulk.flush-interval"
+	suffixIndexPrefix           = ".index-prefix"
+	suffixAwsIamAccessKeyID     = ".aws.access_key_id"
+	suffixAwsIamSecretAccessKey = ".aws.secret_access_key"
+	suffixAwsRegion             = ".aws.region"
 )
 
 // TODO this should be moved next to config.Configuration struct (maybe ./flags package)
@@ -75,6 +78,11 @@ func NewOptions(primaryNamespace string, otherNamespaces ...string) *Options {
 				BulkWorkers:       1,
 				BulkActions:       1000,
 				BulkFlushInterval: time.Millisecond * 200,
+				AwsConfig: config.AwsIamConfiguration{
+					AccessKeyID:     "",
+					SecretAccessKey: "",
+					Region:          "",
+				},
 			},
 			servers:   "http://127.0.0.1:9200",
 			namespace: primaryNamespace,
@@ -146,6 +154,18 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixIndexPrefix,
 		nsConfig.IndexPrefix,
 		"Optional prefix of Jaeger indices. For example \"production\" creates \"production:jaeger-*\".")
+	flagSet.String(
+		nsConfig.namespace+suffixAwsIamAccessKeyID,
+		nsConfig.AwsConfig.AccessKeyID,
+		"The access key name to use if using AWS ElasticSearch and connecting with IAM authentication")
+	flagSet.String(
+		nsConfig.namespace+suffixAwsIamSecretAccessKey,
+		nsConfig.AwsConfig.SecretAccessKey,
+		"The secret access key to use if using AWS ElasticSearch and connecting with IAM authentication")
+	flagSet.String(
+		nsConfig.namespace+suffixAwsRegion,
+		nsConfig.AwsConfig.Region,
+		"The AWS region to use if using AWS ElasticSearch and connecting with IAM authentication")
 }
 
 // InitFromViper initializes Options with properties from viper
@@ -169,6 +189,9 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.BulkActions = v.GetInt(cfg.namespace + suffixBulkActions)
 	cfg.BulkFlushInterval = v.GetDuration(cfg.namespace + suffixBulkFlushInterval)
 	cfg.IndexPrefix = v.GetString(cfg.namespace + suffixIndexPrefix)
+	cfg.AwsConfig.AccessKeyID = v.GetString(cfg.namespace + suffixAwsIamAccessKeyID)
+	cfg.AwsConfig.SecretAccessKey = v.GetString(cfg.namespace + suffixAwsIamSecretAccessKey)
+	cfg.AwsConfig.Region = v.GetString(cfg.namespace + suffixAwsRegion)
 }
 
 // GetPrimary returns primary configuration.

--- a/plugin/storage/es/options_test.go
+++ b/plugin/storage/es/options_test.go
@@ -33,11 +33,15 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, int64(1), primary.NumReplicas)
 	assert.Equal(t, 72*time.Hour, primary.MaxSpanAge)
 	assert.False(t, primary.Sniffer)
+	assert.Equal(t, "", primary.AwsConfig.AccessKeyID)
+	assert.Equal(t, "", primary.AwsConfig.SecretAccessKey)
+	assert.Equal(t, "", primary.AwsConfig.Region)
 
 	aux := opts.Get("archive")
 	assert.Equal(t, primary.Username, aux.Username)
 	assert.Equal(t, primary.Password, aux.Password)
 	assert.Equal(t, primary.Servers, aux.Servers)
+	assert.Equal(t, primary.AwsConfig, aux.AwsConfig)
 }
 
 func TestOptionsWithFlags(t *testing.T) {
@@ -50,7 +54,9 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--es.sniffer=true",
 		"--es.max-span-age=48h",
 		"--es.num-shards=20",
-		"--es.num-replicas=10",
+		"--es.aws.access_key_id=access-key",
+		"--es.aws.secret_access_key=the-secret",
+		"--es.aws.region=us-west-2",
 		// a couple overrides
 		"--es.aux.server-urls=3.3.3.3,4.4.4.4",
 		"--es.aux.max-span-age=24h",
@@ -62,6 +68,9 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "hello", primary.Username)
 	assert.Equal(t, []string{"1.1.1.1", "2.2.2.2"}, primary.Servers)
 	assert.Equal(t, 48*time.Hour, primary.MaxSpanAge)
+	assert.Equal(t, "access-key", primary.AwsConfig.AccessKeyID)
+	assert.Equal(t, "the-secret", primary.AwsConfig.SecretAccessKey)
+	assert.Equal(t, "us-west-2", primary.AwsConfig.Region)
 	assert.True(t, primary.Sniffer)
 
 	aux := opts.Get("es.aux")


### PR DESCRIPTION
Allows clients to specify AWS IAM configuration
details for their connection to ElasticSearch.
We allow this to enable an additional layer
of security for those clients running on AWS.

More details on connecting to ElasticSearch
on AWS here: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html

Signed-off-by: Wesley Kim <wesley@squareup.com>
